### PR TITLE
Added transactional batch bulk delete mode to remove the stored procedure dependency (mainly for Linux-based vNext emulator)

### DIFF
--- a/Eveneum.Tests/Advanced.feature
+++ b/Eveneum.Tests/Advanced.feature
@@ -223,3 +223,22 @@ Scenario: Hard-delete event
 	When I delete event in version 5 in stream B
 	Then the event in version 5 in stream B is hard-deleted
 	And request charge is reported
+
+Scenario: Delete event using transactional batch mode
+	Given transactional batch bulk delete mode
+	And an event store backed by partitioned collection
+	And an existing stream A with 10 events
+	And an existing stream B with 100 events
+	When I delete event in version 5 in stream B
+	Then the event in version 5 in stream B is soft-deleted
+	And request charge is reported
+
+Scenario: Hard-delete event using transactional batch mode
+	Given transactional batch bulk delete mode
+	And hard-delete mode
+	And an event store backed by partitioned collection
+	And an existing stream A with 10 events
+	And an existing stream B with 100 events
+	When I delete event in version 5 in stream B
+	Then the event in version 5 in stream B is hard-deleted
+	And request charge is reported

--- a/Eveneum.Tests/Advanced.feature.cs
+++ b/Eveneum.Tests/Advanced.feature.cs
@@ -961,6 +961,93 @@ this.ScenarioInitialize(scenarioInfo);
             }
             this.ScenarioCleanup();
         }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Delete event using transactional batch mode")]
+        public void DeleteEventUsingTransactionalBatchMode()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Delete event using transactional batch mode", null, tagsOfScenario, argumentsOfScenario, featureTags);
+#line 227
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 228
+ testRunner.Given("transactional batch bulk delete mode", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 229
+ testRunner.And("an event store backed by partitioned collection", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 230
+ testRunner.And("an existing stream A with 10 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 231
+ testRunner.And("an existing stream B with 100 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 232
+ testRunner.When("I delete event in version 5 in stream B", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 233
+ testRunner.Then("the event in version 5 in stream B is soft-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 234
+ testRunner.And("request charge is reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Hard-delete event using transactional batch mode")]
+        public void Hard_DeleteEventUsingTransactionalBatchMode()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Hard-delete event using transactional batch mode", null, tagsOfScenario, argumentsOfScenario, featureTags);
+#line 236
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 237
+ testRunner.Given("transactional batch bulk delete mode", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 238
+ testRunner.And("hard-delete mode", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 239
+ testRunner.And("an event store backed by partitioned collection", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 240
+ testRunner.And("an existing stream A with 10 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 241
+ testRunner.And("an existing stream B with 100 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 242
+ testRunner.When("I delete event in version 5 in stream B", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 243
+ testRunner.Then("the event in version 5 in stream B is hard-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 244
+ testRunner.And("request charge is reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
     }
 }
 #pragma warning restore

--- a/Eveneum.Tests/CommonSteps.cs
+++ b/Eveneum.Tests/CommonSteps.cs
@@ -49,6 +49,12 @@ namespace Eveneum.Tests
             this.Context.EventStoreOptions.StreamTimeToLiveAfterDelete = TimeSpan.FromSeconds(streamTtlAfterDelete);
         }
 
+        [Given(@"transactional batch bulk delete mode")]
+        public void GivenTransactionalBatchBulkDeleteMode()
+        {
+            this.Context.EventStoreOptions.BulkDeleteMode = BulkDeleteMode.TransactionalBatch;
+        }
+
         [Given(@"single snapshot mode")]
         public void GivenSingleSnapshotMode()
         {

--- a/Eveneum.Tests/DeletingSnapshots.feature
+++ b/Eveneum.Tests/DeletingSnapshots.feature
@@ -49,6 +49,41 @@ Scenario: Hard-deleting some snapshots
 	And request charge is reported
 	And 2 deleted documents are reported
 
+Scenario: Deleting some snapshots using transactional batch mode
+	Given transactional batch bulk delete mode
+	And an event store backed by partitioned collection
+	And an existing stream P with 10 events
+	And an existing snapshot for version 5
+	And an existing stream S with 10 events
+	And an existing snapshot for version 1
+	And an existing snapshot for version 3
+	And an existing snapshot for version 5
+	And an existing snapshot for version 7
+	When I delete snapshots older than version 5 from stream S
+	Then the snapshots older than 5 are soft-deleted
+	And snapshots 5 and newer are not soft-deleted
+	And stream P is not soft-deleted
+	And request charge is reported
+	And 2 deleted documents are reported
+
+Scenario: Hard-deleting some snapshots using transactional batch mode
+	Given transactional batch bulk delete mode
+	And hard-delete mode
+	And an event store backed by partitioned collection
+	And an existing stream P with 10 events
+	And an existing snapshot for version 5
+	And an existing stream S with 10 events
+	And an existing snapshot for version 1
+	And an existing snapshot for version 3
+	And an existing snapshot for version 5
+	And an existing snapshot for version 7
+	When I delete snapshots older than version 5 from stream S
+	Then the snapshots older than 5 are hard-deleted
+	And snapshots 5 and newer are not hard-deleted
+	And stream P is not hard-deleted
+	And request charge is reported
+	And 2 deleted documents are reported
+
 Scenario: Hard-Deleting all snapshots
 	Given hard-delete mode
 	And an event store backed by partitioned collection

--- a/Eveneum.Tests/DeletingSnapshots.feature.cs
+++ b/Eveneum.Tests/DeletingSnapshots.feature.cs
@@ -264,12 +264,12 @@ this.ScenarioInitialize(scenarioInfo);
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Hard-Deleting all snapshots")]
-        public void Hard_DeletingAllSnapshots()
+        [NUnit.Framework.DescriptionAttribute("Deleting some snapshots using transactional batch mode")]
+        public void DeletingSomeSnapshotsUsingTransactionalBatchMode()
         {
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Hard-Deleting all snapshots", null, tagsOfScenario, argumentsOfScenario, featureTags);
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Deleting some snapshots using transactional batch mode", null, tagsOfScenario, argumentsOfScenario, featureTags);
 #line 52
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
@@ -281,7 +281,7 @@ this.ScenarioInitialize(scenarioInfo);
             {
                 this.ScenarioStart();
 #line 53
- testRunner.Given("hard-delete mode", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+ testRunner.Given("transactional batch bulk delete mode", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
 #line 54
  testRunner.And("an event store backed by partitioned collection", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
@@ -308,18 +308,153 @@ this.ScenarioInitialize(scenarioInfo);
  testRunner.And("an existing snapshot for version 7", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 62
- testRunner.When("I delete snapshots older than version 999999 from stream S", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+ testRunner.When("I delete snapshots older than version 5 from stream S", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 63
- testRunner.Then("the snapshots older than 10 are hard-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.Then("the snapshots older than 5 are soft-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 64
- testRunner.And("stream P is not hard-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("snapshots 5 and newer are not soft-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 65
- testRunner.And("request charge is reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("stream P is not soft-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 66
+ testRunner.And("request charge is reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 67
+ testRunner.And("2 deleted documents are reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Hard-deleting some snapshots using transactional batch mode")]
+        public void Hard_DeletingSomeSnapshotsUsingTransactionalBatchMode()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Hard-deleting some snapshots using transactional batch mode", null, tagsOfScenario, argumentsOfScenario, featureTags);
+#line 69
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 70
+ testRunner.Given("transactional batch bulk delete mode", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 71
+ testRunner.And("hard-delete mode", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 72
+ testRunner.And("an event store backed by partitioned collection", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 73
+ testRunner.And("an existing stream P with 10 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 74
+ testRunner.And("an existing snapshot for version 5", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 75
+ testRunner.And("an existing stream S with 10 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 76
+ testRunner.And("an existing snapshot for version 1", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 77
+ testRunner.And("an existing snapshot for version 3", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 78
+ testRunner.And("an existing snapshot for version 5", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 79
+ testRunner.And("an existing snapshot for version 7", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 80
+ testRunner.When("I delete snapshots older than version 5 from stream S", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 81
+ testRunner.Then("the snapshots older than 5 are hard-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 82
+ testRunner.And("snapshots 5 and newer are not hard-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 83
+ testRunner.And("stream P is not hard-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 84
+ testRunner.And("request charge is reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 85
+ testRunner.And("2 deleted documents are reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Hard-Deleting all snapshots")]
+        public void Hard_DeletingAllSnapshots()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Hard-Deleting all snapshots", null, tagsOfScenario, argumentsOfScenario, featureTags);
+#line 87
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 88
+ testRunner.Given("hard-delete mode", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 89
+ testRunner.And("an event store backed by partitioned collection", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 90
+ testRunner.And("an existing stream P with 10 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 91
+ testRunner.And("an existing snapshot for version 5", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 92
+ testRunner.And("an existing stream S with 10 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 93
+ testRunner.And("an existing snapshot for version 1", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 94
+ testRunner.And("an existing snapshot for version 3", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 95
+ testRunner.And("an existing snapshot for version 5", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 96
+ testRunner.And("an existing snapshot for version 7", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 97
+ testRunner.When("I delete snapshots older than version 999999 from stream S", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 98
+ testRunner.Then("the snapshots older than 10 are hard-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 99
+ testRunner.And("stream P is not hard-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 100
+ testRunner.And("request charge is reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 101
  testRunner.And("4 deleted documents are reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             }

--- a/Eveneum.Tests/DeletingStream.feature
+++ b/Eveneum.Tests/DeletingStream.feature
@@ -111,5 +111,53 @@ Scenario: TTl-delete stream with events and snapshots
 	And all snapshots are soft-deleted with TTL set to 10 seconds	
 	And request charge is reported	
 	# 10 events, header and 1 snapshot
-	And 12 deleted documents are reported 
+	And 12 deleted documents are reported
+	And stream Z is not soft-deleted
+
+Scenario: Deleting stream with some events and snapshots using transactional batch mode
+	Given transactional batch bulk delete mode
+	And an uninitialized event store backed by partitioned collection
+	And an existing stream P with 10 events
+	And an existing snapshot for version 5
+	And an existing stream S with 5 events
+	And an existing snapshot for version 1
+	And an existing snapshot for version 3
+	When I delete stream S in expected version 5
+	Then the header is soft-deleted
+	And all events are soft-deleted
+	And all snapshots are soft-deleted
+	And stream P is not soft-deleted
+	And request charge is reported
+	And 8 deleted documents are reported
+
+Scenario: Hard-deleting stream with many events and snapshots using transactional batch mode
+	Given transactional batch bulk delete mode
+	And hard-delete mode
+	And an event store backed by partitioned collection
+	And an existing stream P with 10 events
+	And an existing stream S with 250 events
+	And an existing snapshot for version 100
+	And an existing snapshot for version 200
+	When I delete stream S in expected version 250
+	Then the header is hard-deleted
+	And all events are hard-deleted
+	And all snapshots are hard-deleted
+	And stream P is not hard-deleted
+	And request charge is reported
+	And 253 deleted documents are reported
+
+Scenario: TTl-delete stream with events and snapshots using transactional batch mode
+	Given transactional batch bulk delete mode
+	And ttl-delete mode with 10 seconds as ttl
+	And an event store backed by partitioned collection
+	And an existing stream Z with 13 events
+	And an existing stream P with 10 events
+	And an existing snapshot for version 5
+	When I delete stream P in expected version 10
+	Then the header is soft-deleted with TTL set to 10 seconds
+	And all events are soft-deleted with TTL set to 10 seconds
+	And all snapshots are soft-deleted with TTL set to 10 seconds
+	And request charge is reported
+	# 10 events, header and 1 snapshot
+	And 12 deleted documents are reported
 	And stream Z is not soft-deleted

--- a/Eveneum.Tests/DeletingStream.feature.cs
+++ b/Eveneum.Tests/DeletingStream.feature.cs
@@ -529,6 +529,194 @@ this.ScenarioInitialize(scenarioInfo);
             }
             this.ScenarioCleanup();
         }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Deleting stream with some events and snapshots using transactional batch mode")]
+        public void DeletingStreamWithSomeEventsAndSnapshotsUsingTransactionalBatchMode()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Deleting stream with some events and snapshots using transactional batch mode", null, tagsOfScenario, argumentsOfScenario, featureTags);
+#line 117
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 118
+ testRunner.Given("transactional batch bulk delete mode", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 119
+ testRunner.And("an uninitialized event store backed by partitioned collection", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 120
+ testRunner.And("an existing stream P with 10 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 121
+ testRunner.And("an existing snapshot for version 5", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 122
+ testRunner.And("an existing stream S with 5 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 123
+ testRunner.And("an existing snapshot for version 1", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 124
+ testRunner.And("an existing snapshot for version 3", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 125
+ testRunner.When("I delete stream S in expected version 5", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 126
+ testRunner.Then("the header is soft-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 127
+ testRunner.And("all events are soft-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 128
+ testRunner.And("all snapshots are soft-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 129
+ testRunner.And("stream P is not soft-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 130
+ testRunner.And("request charge is reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 131
+ testRunner.And("8 deleted documents are reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Hard-deleting stream with many events and snapshots using transactional batch mod" +
+            "e")]
+        public void Hard_DeletingStreamWithManyEventsAndSnapshotsUsingTransactionalBatchMode()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Hard-deleting stream with many events and snapshots using transactional batch mod" +
+                    "e", null, tagsOfScenario, argumentsOfScenario, featureTags);
+#line 133
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 134
+ testRunner.Given("transactional batch bulk delete mode", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 135
+ testRunner.And("hard-delete mode", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 136
+ testRunner.And("an event store backed by partitioned collection", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 137
+ testRunner.And("an existing stream P with 10 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 138
+ testRunner.And("an existing stream S with 250 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 139
+ testRunner.And("an existing snapshot for version 100", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 140
+ testRunner.And("an existing snapshot for version 200", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 141
+ testRunner.When("I delete stream S in expected version 250", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 142
+ testRunner.Then("the header is hard-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 143
+ testRunner.And("all events are hard-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 144
+ testRunner.And("all snapshots are hard-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 145
+ testRunner.And("stream P is not hard-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 146
+ testRunner.And("request charge is reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 147
+ testRunner.And("253 deleted documents are reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("TTl-delete stream with events and snapshots using transactional batch mode")]
+        public void TTl_DeleteStreamWithEventsAndSnapshotsUsingTransactionalBatchMode()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("TTl-delete stream with events and snapshots using transactional batch mode", null, tagsOfScenario, argumentsOfScenario, featureTags);
+#line 149
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            if ((TagHelper.ContainsIgnoreTag(tagsOfScenario) || TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 150
+ testRunner.Given("transactional batch bulk delete mode", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 151
+ testRunner.And("ttl-delete mode with 10 seconds as ttl", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 152
+ testRunner.And("an event store backed by partitioned collection", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 153
+ testRunner.And("an existing stream Z with 13 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 154
+ testRunner.And("an existing stream P with 10 events", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 155
+ testRunner.And("an existing snapshot for version 5", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 156
+ testRunner.When("I delete stream P in expected version 10", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 157
+ testRunner.Then("the header is soft-deleted with TTL set to 10 seconds", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 158
+ testRunner.And("all events are soft-deleted with TTL set to 10 seconds", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 159
+ testRunner.And("all snapshots are soft-deleted with TTL set to 10 seconds", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 160
+ testRunner.And("request charge is reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 162
+ testRunner.And("12 deleted documents are reported", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 163
+ testRunner.And("stream Z is not soft-deleted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
     }
 }
 #pragma warning restore

--- a/Eveneum/BulkDeleteMode.cs
+++ b/Eveneum/BulkDeleteMode.cs
@@ -1,0 +1,8 @@
+namespace Eveneum
+{
+    public enum BulkDeleteMode
+    {
+        StoredProcedure = 1, // uses the BulkDelete stored procedure created by Initialize()
+        TransactionalBatch = 2, // uses transactional batches, no stored procedures required (compatible with the Linux-based (vNext) Cosmos DB emulator)
+    }
+}

--- a/Eveneum/EventStore.cs
+++ b/Eveneum/EventStore.cs
@@ -22,6 +22,7 @@ namespace Eveneum
         public readonly Container Container;
 
         public DeleteMode DeleteMode { get; }
+        public BulkDeleteMode BulkDeleteMode { get; }
         public TimeSpan StreamTimeToLiveAfterDelete { get; }
         public byte BatchSize { get; }
         public int QueryMaxItemCount { get; }
@@ -40,6 +41,7 @@ namespace Eveneum
             options = options ?? new EventStoreOptions();
 
             this.DeleteMode = options.DeleteMode;
+            this.BulkDeleteMode = options.BulkDeleteMode;
             this.StreamTimeToLiveAfterDelete = options.StreamTimeToLiveAfterDelete;
             this.BatchSize = Math.Min(options.BatchSize, (byte)100); // Maximum batch size supported by CosmosDB
             this.QueryMaxItemCount = options.QueryMaxItemCount;
@@ -50,7 +52,8 @@ namespace Eveneum
 
         public async Task Initialize(CancellationToken cancellationToken = default)
         {
-            await CreateStoredProcedure(BulkDeleteStoredProc, "BulkDelete", cancellationToken);
+            if (this.BulkDeleteMode == BulkDeleteMode.StoredProcedure)
+                await CreateStoredProcedure(BulkDeleteStoredProc, "BulkDelete", cancellationToken);
         }
 
         public Task<StreamResponse> ReadStreamAsOfVersion(string streamId, ulong version, CancellationToken cancellationToken = default) =>
@@ -261,10 +264,6 @@ namespace Eveneum
             if (existingHeader.Version != expectedVersion)
                 throw new OptimisticConcurrencyException(streamId, requestCharge, expectedVersion, existingHeader.Version);
 
-            var partitionKey = new PartitionKey(streamId);
-            ulong deletedDocuments = 0;
-
-            StoredProcedureExecuteResponse<BulkDeleteResponse> response;
             var query = $"SELECT * FROM c";
 
             var useSoftDeleteMode = (this.DeleteMode == DeleteMode.SoftDelete) || (this.DeleteMode == DeleteMode.TtlDelete);
@@ -272,17 +271,11 @@ namespace Eveneum
             if (useSoftDeleteMode)
                 query += " WHERE c.Deleted = false";
 
-            do
-            {
-                var ttl = this.DeleteMode == DeleteMode.TtlDelete ? StreamTimeToLiveAfterDelete.TotalSeconds  : -1;                
-                response = await this.Container.Scripts.ExecuteStoredProcedureAsync<BulkDeleteResponse>(BulkDeleteStoredProc, partitionKey, new object[] { query, useSoftDeleteMode, ttl}, cancellationToken: cancellationToken);
+            var ttl = this.DeleteMode == DeleteMode.TtlDelete ? StreamTimeToLiveAfterDelete.TotalSeconds : -1;
 
-                requestCharge += response.RequestCharge;
-                deletedDocuments += response.Resource.Deleted;
-            }
-            while (response.Resource.Continuation);
+            var deleteResponse = await this.BulkDeleteDocuments(streamId, query, useSoftDeleteMode, ttl, cancellationToken);
 
-            return new DeleteResponse(deletedDocuments, requestCharge);
+            return new DeleteResponse(deleteResponse.DeletedDocuments, requestCharge + deleteResponse.RequestCharge);
         }
 
         public async Task<Response> CreateSnapshot(string streamId, ulong version, object snapshot, object metadata = null, bool deleteOlderSnapshots = false, CancellationToken cancellationToken = default)
@@ -417,20 +410,96 @@ namespace Eveneum
             var headerResponse = await this.ReadHeader(streamId, cancellationToken);
 
             var requestCharge = headerResponse.RequestCharge;
-            ulong deletedSnapshots = 0;
-            StoredProcedureExecuteResponse<BulkDeleteResponse> response;
-            if (this.DeleteMode == DeleteMode.SoftDelete)
+            var useSoftDeleteMode = this.DeleteMode == DeleteMode.SoftDelete;
+
+            if (useSoftDeleteMode)
                 query += " and c.Deleted = false";
+
+            var deleteResponse = await this.BulkDeleteDocuments(streamId, query, useSoftDeleteMode, -1, cancellationToken);
+
+            return new DeleteResponse(deleteResponse.DeletedDocuments, requestCharge + deleteResponse.RequestCharge);
+        }
+
+        private Task<DeleteResponse> BulkDeleteDocuments(string streamId, string query, bool softDelete, double ttl, CancellationToken cancellationToken) =>
+            this.BulkDeleteMode == BulkDeleteMode.TransactionalBatch
+                ? this.BulkDeleteDocumentsUsingTransactionalBatch(streamId, query, softDelete, ttl, cancellationToken)
+                : this.BulkDeleteDocumentsUsingStoredProcedure(streamId, query, softDelete, ttl, cancellationToken);
+
+        private async Task<DeleteResponse> BulkDeleteDocumentsUsingStoredProcedure(string streamId, string query, bool softDelete, double ttl, CancellationToken cancellationToken)
+        {
+            double requestCharge = 0;
+            ulong deletedDocuments = 0;
+            StoredProcedureExecuteResponse<BulkDeleteResponse> response;
 
             do
             {
-                response = await this.Container.Scripts.ExecuteStoredProcedureAsync<BulkDeleteResponse>(BulkDeleteStoredProc, new PartitionKey(streamId), new object[] { query, this.DeleteMode == DeleteMode.SoftDelete }, cancellationToken: cancellationToken);
+                response = await this.Container.Scripts.ExecuteStoredProcedureAsync<BulkDeleteResponse>(BulkDeleteStoredProc, new PartitionKey(streamId), new object[] { query, softDelete, ttl }, cancellationToken: cancellationToken);
+
                 requestCharge += response.RequestCharge;
-                deletedSnapshots += response.Resource.Deleted;
+                deletedDocuments += response.Resource.Deleted;
             }
             while (response.Resource.Continuation);
 
-            return new DeleteResponse(deletedSnapshots, requestCharge);
+            return new DeleteResponse(deletedDocuments, requestCharge);
+        }
+
+        private async Task<DeleteResponse> BulkDeleteDocumentsUsingTransactionalBatch(string streamId, string query, bool softDelete, double ttl, CancellationToken cancellationToken)
+        {
+            var partitionKey = new PartitionKey(streamId);
+
+            double requestCharge = 0;
+            ulong deletedDocuments = 0;
+            List<EveneumDocument> documents;
+
+            do
+            {
+                documents = new List<EveneumDocument>();
+
+                using (var iterator = this.Container.GetItemQueryIterator<EveneumDocument>(query, requestOptions: new QueryRequestOptions { PartitionKey = partitionKey, MaxItemCount = this.QueryMaxItemCount }))
+                {
+                    while (iterator.HasMoreResults && documents.Count == 0)
+                    {
+                        var page = await iterator.ReadNextAsync(cancellationToken);
+
+                        requestCharge += page.RequestCharge;
+                        documents.AddRange(page);
+                    }
+                }
+
+                foreach (var batch in documents.Batch(this.BatchSize))
+                {
+                    if (!batch.Any())
+                        continue;
+
+                    var transaction = this.Container.CreateTransactionalBatch(partitionKey);
+
+                    foreach (var document in batch)
+                    {
+                        if (softDelete)
+                        {
+                            document.Deleted = true;
+
+                            if (ttl > 0)
+                                document.TimeToLive = (int)ttl;
+
+                            transaction.ReplaceItem(document.Id, document, new TransactionalBatchItemRequestOptions { IfMatchEtag = document.ETag });
+                        }
+                        else
+                            transaction.DeleteItem(document.Id, new TransactionalBatchItemRequestOptions { IfMatchEtag = document.ETag });
+                    }
+
+                    using var response = await transaction.ExecuteAsync(cancellationToken);
+                    requestCharge += response.RequestCharge;
+
+                    if (!response.IsSuccessStatusCode)
+                        throw new WriteException(streamId, requestCharge, response.ErrorMessage, response.StatusCode);
+
+                    deletedDocuments += (ulong)batch.Count();
+                }
+            }
+            while (documents.Count > 0);
+
+            return new DeleteResponse(deletedDocuments, requestCharge);
         }
 
         private async Task CreateStoredProcedure(string procedureId, string procedureFileName, CancellationToken cancellationToken = default)

--- a/Eveneum/EventStoreOptions.cs
+++ b/Eveneum/EventStoreOptions.cs
@@ -8,6 +8,7 @@ namespace Eveneum
     public class EventStoreOptions
     {
         public DeleteMode DeleteMode { get; set; } = DeleteMode.SoftDelete;
+        public BulkDeleteMode BulkDeleteMode { get; set; } = BulkDeleteMode.StoredProcedure;
         public byte BatchSize { get; set; } = 100;
         public int QueryMaxItemCount { get; set; } = 1000;
         public JsonSerializer JsonSerializer { get; set; } = JsonSerializer.CreateDefault();


### PR DESCRIPTION
I'm working on an older project using this library and want to move away from the Windows emulator for local development and eventually run e2e tests against the vNext emulator on Linux-based CI/CD, and the stored procedure is the only blocker for that (since Linux-based (vNext) Cosmos DB emulator does not support stored procedures ([not planned](https://learn.microsoft.com/en-us/azure/cosmos-db/emulator-linux#feature-support)), so Eveneum's `BulkDelete` procedure makes the library unusable there.)

I've added `EventStoreOptions.BulkDeleteMode`:
- `StoredProcedure` (default): current behavior, unchanged.
- `TransactionalBatch`: bulk deletes run client-side (query + transactional batches, same soft/hard/TTL delete semantics and etag checks as the sproc). `Initialize()` skips stored procedure creation, so no server-side scripts are needed at all. And since it's meant for emulator use-cases - I haven't tried to optimize it for performance.

Non-breaking: the default keeps existing behavior.